### PR TITLE
fix(rewrite): rewrite question mark

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM caddy/caddy:2.0.0-beta.20-alpine
+FROM openresty/openresty:1.15.8.3-alpine
 
-WORKDIR /app
-COPY ./static /app/static
-
-# --browse is added for health check purposes
-CMD ["caddy", "file-server", "--browse", "--listen", ":8080", "--root", "/app/static"]
+# Overwrite the default openresty nginx.conf
+COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+COPY ./static /usr/share/nginx/html/static

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ The set-up is Docker centric and uses NGINX to host the static files.
 The built image is already available. This pulls and just runs the webserver.
 
 ```bash
-docker pull dsaidgovsg/folium-resource-server:v0.1.1_folium-v0.10.1
-docker run --rm -it -p 8080:8080 dsaidgovsg/folium-resource-server:v0.1.1_folium-v0.10.1
+docker pull dsaidgovsg/folium-resource-server:v0.1.2_folium-v0.10.1
+docker run --rm -it -p 8080:8080 dsaidgovsg/folium-resource-server:v0.1.2_folium-v0.10.1
 ```
 
 To test that this is working, enter the following link into your web browser:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Folium requires two sets of external resources:
 
 ## Set-Up
 
-The set-up is Docker centric and uses Caddy 2 to host the static files.
+The set-up is Docker centric and uses NGINX to host the static files.
 
 ### Pull and run
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,27 @@
+events {}
+
+http {
+    server {
+        listen 8080;
+
+        location / {
+            if ($args) {
+                # Need to set variable so that rewrite expand this var literally
+                # and the ? here wouldn't interfere with the literal ? to mean
+                # dropping of query parameters
+                set $fargs ?$args;
+                rewrite ^(.+)$ $1$fargs? last;
+
+                # The alternative redirect works too, but requires
+                # set_escape_url in order to follow the actual URL link
+                # set_escape_url requires openresty variant of NGINX
+                # set_escape_uri $eargs $args;
+                # rewrite ^(.+)$ $1%%3F$eargs? redirect;
+            }
+
+            root /usr/share/nginx/html/static;
+            index index.html;
+            autoindex on;
+        }
+    }
+}


### PR DESCRIPTION
This is to make resources like `font-awesome`, to work when there is
query param question mark symbol in the given URL. When one uses the
browser to download the file, this issue does not occur since the file
browser will automatically convert question mark into its escaped form.

Note that static files with hex / anchor link would not work, since hex
is a purely client thing and never made it to NGINX. This is
unresolvable but should be okay since these resources are usually
backups of other font URLs that are non-anchor based.

The set-up now switches to NGINX since it can perform rewrite more
easily.

Prepare for v0.1.2 and update the README.md.